### PR TITLE
Remove emoji that doesn't exist anymore

### DIFF
--- a/cmds/urban.js
+++ b/cmds/urban.js
@@ -24,7 +24,6 @@ module.exports.run = async (bot, message, args) => {
                     `That doesn't appear to have an urban definition. Why don't you add one?`,
                     `I can't find a definition for this.`,
                     `Doesn't appear to be here. Why don't you say what it might be? That's basically what the urban dictionary is <:tearthonk:383856193073840129>`,
-                    `<:rauf:383848644413095937>`,
                     `<:tearthonk:383856193073840129>`,
                     `<:sweats:370656909134659604>`,
                     `<a:gone:393837219854680066>`


### PR DESCRIPTION
Found an emoji (:rauf:) in the code as a response, but doesn't exist anymore